### PR TITLE
Fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>21</java.version>
         <kotlin.version>2.1.10</kotlin.version>
         <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
-        <embabel-agent.version>0.3.1-SNAPSHOT</embabel-agent.version>
+        <embabel-agent.version>0.3.5-SNAPSHOT</embabel-agent.version>
     </properties>
 
     <dependencies>

--- a/src/main/kotlin/com/embabel/agent/domain/persistence/EntityFinderTools.kt
+++ b/src/main/kotlin/com/embabel/agent/domain/persistence/EntityFinderTools.kt
@@ -1,6 +1,6 @@
 package com.embabel.agent.domain.persistence
 
-import com.embabel.agent.api.annotation.waitFor
+import com.embabel.agent.core.hitl.waitFor
 import com.embabel.agent.api.common.PromptRunner
 import com.embabel.agent.api.common.createObjectIfPossible
 import com.embabel.agent.core.hitl.ConfirmationRequest

--- a/src/main/kotlin/com/embabel/movie/chatbot/ChatConfiguration.kt
+++ b/src/main/kotlin/com/embabel/movie/chatbot/ChatConfiguration.kt
@@ -32,7 +32,7 @@ class ChatConfiguration {
     fun chatbot(agentPlatform: AgentPlatform): Chatbot {
         return AgentProcessChatbot.utilityFromPlatform(
             agentPlatform,
-            Verbosity().showPrompts()
+            verbosity = Verbosity().showPrompts()
         )
     }
 }

--- a/src/main/kotlin/com/embabel/movie/domain/MovieBuff.kt
+++ b/src/main/kotlin/com/embabel/movie/domain/MovieBuff.kt
@@ -1,7 +1,7 @@
 package com.embabel.movie.domain
 
 import com.embabel.agent.api.identity.User
-import com.embabel.agent.prompt.persona.Persona
+import com.embabel.agent.prompt.persona.PersonaSpec
 import com.embabel.common.core.types.Timestamped
 import com.embabel.movie.agent.OneThroughTen
 import jakarta.persistence.*
@@ -110,5 +110,4 @@ data class MovieGuide(
     override val persona: String,
     override val voice: String,
     override val objective: String,
-    override val role: String?,
-) : Persona
+) : PersonaSpec

--- a/src/test/kotlin/com/embabel/movie/MovieFinderTest.kt
+++ b/src/test/kotlin/com/embabel/movie/MovieFinderTest.kt
@@ -15,16 +15,15 @@
  */
 package com.embabel.movie
 
-import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.test.unit.FakeOperationContext
 import com.embabel.movie.agent.MovieFinderAgent
 import com.embabel.movie.agent.MovieFinderConfig
 import com.embabel.movie.domain.MovieBuff
 import com.embabel.movie.domain.MovieBuffRepository
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
+import com.embabel.movie.service.AiHelpers
+import com.embabel.movie.service.TasteProfile
+import io.mockk.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -46,25 +45,19 @@ class MovieFinderTest {
         fun `test analyze taste profile`() {
             val repository = mockk<MovieBuffRepository>()
             every { repository.findAll() } returns listOf(testMovieBuff())
-            val mockOperationContext = mockk<OperationContext>()
-            val prompt = slot<String>()
-            every { mockOperationContext.promptRunner(any()).generateText(capture(prompt)) } returns "test"
+            val fakeContext = FakeOperationContext()
+            val tasteProfile = TasteProfile("Loves noir and complex plots")
+            val aiHelpers = mockk<AiHelpers>()
+            val capturedMovieBuff = slot<MovieBuff>()
+            every { aiHelpers.analyzeTasteProfile(capture(capturedMovieBuff), any(), any()) } returns tasteProfile
             val movieFinder =
-                MovieFinderAgent(mockk(), mockk(), MovieFinderConfig())
+                MovieFinderAgent(mockk(), aiHelpers, MovieFinderConfig())
             val movieBuff = repository.findAll().first()
 
-            val dmb = movieFinder.analyzeTasteProfile(movieBuff, mockOperationContext)
+            val dmb = movieFinder.analyzeTasteProfile(movieBuff, fakeContext)
             assertEquals(movieBuff, dmb.movieBuff)
-            assertTrue(
-                prompt.captured.contains(movieBuff.name),
-                "Prompt should contain movie buff name '${movieBuff.name}': ${prompt.captured}"
-            )
-            movieBuff.hobbies.forEach { hobby ->
-                assertTrue(
-                    prompt.captured.contains(hobby),
-                    "Prompt should contain movie buff about '${movieBuff.about}': ${prompt.captured}"
-                )
-            }
+            assertEquals(tasteProfile, dmb.tasteProfile)
+            assertEquals(movieBuff, capturedMovieBuff.captured)
         }
 
     }


### PR DESCRIPTION
This pull request updates dependencies, refactors code to use newer or more appropriate types and modules, and improves the test setup and assertions for the `MovieFinderTest`. The changes modernize the codebase, align it with the latest APIs, and make the tests more robust and focused.

**Dependency and type updates:**

* Updated the `embabel-agent` dependency version from `0.3.1-SNAPSHOT` to `0.3.5-SNAPSHOT` in `pom.xml` to use the latest agent features and fixes.
* Replaced usage of `Persona` with the newer `PersonaSpec` interface in the `MovieGuide` data class and import statements in `MovieBuff.kt` for improved persona modeling. [[1]](diffhunk://#diff-8b7c9262f78a2c3e26f033638259147ab66276cc400bc1d01dccf908e16f080fL4-R4) [[2]](diffhunk://#diff-8b7c9262f78a2c3e26f033638259147ab66276cc400bc1d01dccf908e16f080fL113-R113)

**Code refactoring and API alignment:**

* Updated imports in `EntityFinderTools.kt` to use the correct `waitFor` annotation from `com.embabel.agent.core.hitl` instead of the deprecated location, ensuring proper annotation usage.
* Clarified the parameter name in the `ChatConfiguration.chatbot` method to explicitly use the `verbosity` named argument for better readability.

**Testing improvements:**

* Switched from `OperationContext` to `FakeOperationContext` and refactored the `MovieFinderTest` to use a mocked `AiHelpers` service and improved assertions, making the test more deterministic and focused on business logic rather than prompt content. [[1]](diffhunk://#diff-70778a49a1aa576c2fd4aa5db872c203cea18e2d0532e2cc103802bb76b0e201L18-L27) [[2]](diffhunk://#diff-70778a49a1aa576c2fd4aa5db872c203cea18e2d0532e2cc103802bb76b0e201L49-R60)